### PR TITLE
Remove 'mockery' dependency (#34)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Suggests:
     spelling,
     knitr,
     rmarkdown,
-    mockery,
     shiny
 Language: en-US
 URL: https://github.com/szymanskir/featureflag

--- a/R/feature_flag-percentage.R
+++ b/R/feature_flag-percentage.R
@@ -66,6 +66,13 @@ is_percentage_feature_flag <- function(feature_flag) {
 is_enabled.percentage_feature_flag <- function(feature_flag) { # nolint
   is_percentage_feature_flag(feature_flag)
 
-  random_value <- stats::runif(n = 1, min = 0, max = 1)
+  random_value <- get_random_value()
   random_value <= feature_flag$percentage
+}
+
+#' Samples a value from the uniform distribution
+#' @noRd
+#'
+get_random_value <- function() {
+  stats::runif(n = 1, min = 0, max = 1)
 }

--- a/R/feature_flag-time_period.R
+++ b/R/feature_flag-time_period.R
@@ -85,10 +85,17 @@ is_time_period_feature_flag <- function(feature_flag) {
 is_enabled.time_period_feature_flag <- function(feature_flag) { # nolint
   is_time_period_feature_flag(feature_flag)
 
-  current_datetime <- Sys.time()
+  current_datetime <- get_current_time()
 
   is_from_boundary_met <- is.null(feature_flag$from) || (feature_flag$from <= current_datetime)
   is_to_boundary_met <- is.null(feature_flag$to) || (feature_flag$to >= current_datetime)
 
   is_from_boundary_met && is_to_boundary_met
+}
+
+
+#' Returns the current time
+#' @noRd
+get_current_time <- function() {
+  Sys.time()
 }

--- a/tests/testthat/test-feature_flag-percentage.R
+++ b/tests/testthat/test-feature_flag-percentage.R
@@ -1,6 +1,6 @@
 test_that("Percentage feature flag is enabled when random value is lower than threshold", {
   feature_flag <- create_percentage_feature_flag(percentage = 0.7)
-  mockery::stub(is_enabled.percentage_feature_flag, "stats::runif", function(...) 0.3)
+  local_mocked_bindings(get_random_value = function() 0.3)
 
   result <- is_enabled(feature_flag)
 
@@ -10,7 +10,7 @@ test_that("Percentage feature flag is enabled when random value is lower than th
 
 test_that("Percentage feature flag is disabled when random value is higher than threshold", {
   feature_flag <- create_percentage_feature_flag(percentage = 0.7)
-  mockery::stub(is_enabled.percentage_feature_flag, "stats::runif", function(...) 0.8)
+  local_mocked_bindings(get_random_value = function() 0.8)
 
   result <- is_enabled(feature_flag)
 

--- a/tests/testthat/test-feature_flag-time_period.R
+++ b/tests/testthat/test-feature_flag-time_period.R
@@ -5,7 +5,7 @@ test_that("Time period feature flags are enabled within specified boundaries", {
   )
 
   sys_time_stub <- function() ISOdatetime(2020, 1, 1, 12, 0, 0, tz = "UTC")
-  mockery::stub(is_enabled.time_period_feature_flag, "Sys.time", sys_time_stub)
+  local_mocked_bindings(get_current_time = sys_time_stub)
 
   expect_true(is_enabled(feature_flag))
 })
@@ -18,7 +18,7 @@ test_that("Time period feature flags are disabled when not in specified boundari
   )
 
   sys_time_stub <- function() ISOdatetime(2020, 1, 1, 15, 0, 0, tz = "UTC")
-  mockery::stub(is_enabled.time_period_feature_flag, "Sys.time", sys_time_stub)
+  local_mocked_bindings(get_current_time = sys_time_stub)
 
   expect_false(is_enabled(feature_flag))
 })
@@ -29,7 +29,7 @@ test_that("Time period feature flags bounded from are enabled from specified bou
   )
 
   sys_time_stub <- function() ISOdatetime(2920, 1, 1, 15, 0, 0, tz = "UTC")
-  mockery::stub(is_enabled.time_period_feature_flag, "Sys.time", sys_time_stub)
+  local_mocked_bindings(get_current_time = sys_time_stub)
 
   expect_true(is_enabled(feature_flag))
 })
@@ -41,7 +41,7 @@ test_that("Time period feature flags bounded from are disabled to specified boun
   )
 
   sys_time_stub <- function() ISOdatetime(2020, 1, 1, 9, 59, 59, tz = "UTC")
-  mockery::stub(is_enabled.time_period_feature_flag, "Sys.time", sys_time_stub)
+  local_mocked_bindings(get_current_time = sys_time_stub)
 
   expect_false(is_enabled(feature_flag))
 })
@@ -53,7 +53,7 @@ test_that("Time period feature flags bounded `to` are enabled until specified bo
   )
 
   sys_time_stub <- function() ISOdatetime(1990, 1, 1, 9, 0, 0, tz = "UTC")
-  mockery::stub(is_enabled.time_period_feature_flag, "Sys.time", sys_time_stub)
+  local_mocked_bindings(get_current_time = sys_time_stub)
 
   expect_true(is_enabled(feature_flag))
 })
@@ -65,7 +65,7 @@ test_that("Time period feature flags bounded to are disabled from specified boun
   )
 
   sys_time_stub <- function() ISOdatetime(2020, 1, 1, 10, 59, 59, tz = "UTC")
-  mockery::stub(is_enabled.time_period_feature_flag, "Sys.time", sys_time_stub)
+  local_mocked_bindings(get_current_time = sys_time_stub)
 
   expect_false(is_enabled(feature_flag))
 })


### PR DESCRIPTION
- [x] NEWS is updated if applicable (not a user facing changes)
- [x] Docs are updated if applicable (not a user facing changes)
- [x] Self review was performed
- [x] CI is passing

Closes #34 